### PR TITLE
Ajustando erro em nível de acesso da função

### DIFF
--- a/includes/class-wc-pagarme-gateway.php
+++ b/includes/class-wc-pagarme-gateway.php
@@ -266,7 +266,7 @@ class WC_Pagarme_Gateway extends WC_Payment_Gateway {
 	 *
 	 * @return string          Displays the error messages.
 	 */
-	protected function add_error( $messages ) {
+	public function add_error( $messages ) {
 		foreach ( $messages as $message ) {
 			wc_add_notice( $message['message'], 'error' );
 		}


### PR DESCRIPTION
Erro ao ativar o plugin no Woocommerce: Fatal error: Access level to WC_Pagarme_Gateway::add_error() must be public (as in class WC_Settings_API) in C:\laragon\www\delivery\wp-content\plugins\woocommerce-pagarme-marketplace\includes\class-wc-pagarme-gateway.php on line 541